### PR TITLE
Fix/login response

### DIFF
--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -23,20 +23,18 @@ class LoginScreen extends Component {
     this.setState({ loading: true })
 
     const user = await this.props.login(email, password).then(response => {
-      return response.payload.data
+      return response
     })
-    if (!user) {
+
+    this.setState({ loading: false })
+    console.log(user.error)
+    if (user.error) {
       Alert.alert(
         'Hubo un problema iniciando sesión. Por favor intentalo de nuevo.'
-      )
-    } else if (!user.email) {
-      Alert.alert(
-        'Las credenciales ingresadas son inválidas. Por favor intentalo de nuevo.'
       )
     } else {
       this.props.navigation.navigate('Home')
     }
-    await this.setState({ loading: false })
   }
 
   render() {

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -27,7 +27,7 @@ class LoginScreen extends Component {
     })
 
     this.setState({ loading: false })
-    console.log(user.error)
+
     if (user.error) {
       Alert.alert(
         'Hubo un problema iniciando sesión. Por favor intentalo de nuevo.'


### PR DESCRIPTION
Error: cuando se ingresaban credenciales erróneas, se evaluaba response.payload.data por lo que era undefined.

Fix login:

- Se retorna solo `response` para no obtener undefined cuando la API devuelva error. Dentro de `if (user.error)` se podría evaluar los otros errores.
- Se cambia el estado de loading: false previa navegación a Home para evitar warning.